### PR TITLE
feat(search): implement offer search with filters

### DIFF
--- a/src/main/java/uca/github/org/controllers/InternshipController.java
+++ b/src/main/java/uca/github/org/controllers/InternshipController.java
@@ -1,0 +1,34 @@
+package uca.github.org.controllers;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import uca.github.org.services.InternshipService;
+
+@Controller
+@RequestMapping("/offers")
+@RequiredArgsConstructor
+public class InternshipController {
+
+    private final InternshipService internshipService;
+
+    @GetMapping("/search")
+    public String searchOffers(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String location,
+            @RequestParam(required = false) String sector,
+            @RequestParam(required = false) String duration,
+            @RequestParam(required = false) String company,
+            Model model) {
+
+        var results = internshipService.searchInternships(
+                keyword, location, sector, duration, company);
+
+        model.addAttribute("results", results);
+        model.addAttribute("keyword", keyword);
+        return "pages/search";
+    }
+}

--- a/src/main/java/uca/github/org/repositories/InternshipRepositiroy.java
+++ b/src/main/java/uca/github/org/repositories/InternshipRepositiroy.java
@@ -1,0 +1,27 @@
+package uca.github.org.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import uca.github.org.models.Internship;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface InternshipRepositiroy extends JpaRepository<Internship, UUID> {
+    @Query("SELECT i FROM Internship i WHERE " +
+            "(:keyword IS NULL OR LOWER(i.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+            "LOWER(i.description) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND " +
+            "(:location IS NULL OR LOWER(i.location) LIKE LOWER(CONCAT('%', :location, '%'))) AND " +
+            "(:sector IS NULL OR LOWER(i.sector) LIKE LOWER(CONCAT('%', :sector, '%'))) AND " +
+            "(:duration IS NULL OR LOWER(i.duration) LIKE LOWER(CONCAT('%', :duration, '%'))) AND " +
+            "(:company IS NULL OR LOWER(i.company) LIKE LOWER(CONCAT('%', :company, '%'))) AND " +
+            "i.status = 'ACTIVE'")
+    List<Internship> searchInternships(
+            @Param("keyword") String keyword,
+            @Param("location") String location,
+            @Param("sector") String sector,
+            @Param("duration") String duration,
+            @Param("company") String company
+    );
+}

--- a/src/main/java/uca/github/org/repositories/InternshipRepostiroy.java
+++ b/src/main/java/uca/github/org/repositories/InternshipRepostiroy.java
@@ -1,5 +1,0 @@
-package uca.github.org.repositories;
-
-public class InternshipRepostiroy {
-    
-}

--- a/src/main/java/uca/github/org/services/InternshipService.java
+++ b/src/main/java/uca/github/org/services/InternshipService.java
@@ -1,0 +1,14 @@
+package uca.github.org.services;
+
+import uca.github.org.models.Internship;
+import java.util.List;
+
+public interface InternshipService {
+    List<Internship> searchInternships(
+            String keyword,
+            String location,
+            String sector,
+            String duration,
+            String company
+    );
+}

--- a/src/main/java/uca/github/org/services/impl/InternshipServiceImpl.java
+++ b/src/main/java/uca/github/org/services/impl/InternshipServiceImpl.java
@@ -1,0 +1,27 @@
+package uca.github.org.services.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uca.github.org.models.Internship;
+import uca.github.org.repositories.InternshipRepositiroy;
+import uca.github.org.services.InternshipService;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InternshipServiceImpl implements InternshipService {
+
+    private final InternshipRepositiroy internshipRepository;
+
+    @Override
+    public List<Internship> searchInternships(
+            String keyword,
+            String location,
+            String sector,
+            String duration,
+            String company) {
+
+        return internshipRepository
+                .searchInternships(keyword, location, sector, duration, company);
+    }
+}

--- a/src/main/resources/templates/pages/search.html
+++ b/src/main/resources/templates/pages/search.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layouts/layout :: layout(~{::section})}">
+<body>
+<section>
+    <div class="container mt-4">
+
+        <!-- Search Form -->
+        <form th:action="@{/offers/search}" method="get">
+            <div class="row g-3">
+                <div class="col-md-4">
+                    <input type="text" name="keyword" class="form-control"
+                           placeholder="Mot-clé..." th:value="${keyword}"/>
+                </div>
+                <div class="col-md-2">
+                    <input type="text" name="location" class="form-control"
+                           placeholder="Ville..."/>
+                </div>
+                <div class="col-md-2">
+                    <input type="text" name="sector" class="form-control"
+                           placeholder="Secteur..."/>
+                </div>
+                <div class="col-md-2">
+                    <input type="text" name="duration" class="form-control"
+                           placeholder="Durée..."/>
+                </div>
+                <div class="col-md-2">
+                    <button type="submit" class="btn btn-primary w-100">
+                        🔍 Rechercher
+                    </button>
+                </div>
+            </div>
+        </form>
+
+        <!-- Results -->
+        <div class="mt-4">
+            <div th:if="${results == null or results.isEmpty()}">
+                <div class="alert alert-info text-center">
+                    Aucun stage trouvé. Essayez d'autres critères.
+                </div>
+            </div>
+
+            <div th:each="offer : ${results}" class="card mb-3">
+                <div class="card-body">
+                    <h5 class="card-title" th:text="${offer.title}"></h5>
+                    <p class="card-text">
+                        🏢 <span th:text="${offer.company}"></span> |
+                        📍 <span th:text="${offer.location}"></span> |
+                        ⏱️ <span th:text="${offer.duration}"></span>
+                    </p>
+                    <p class="card-text" th:text="${offer.description}"></p>
+                    <a th:href="@{/offers/{id}(id=${offer.id})}"
+                       class="btn btn-outline-primary btn-sm">
+                        Voir l'offre
+                    </a>
+                </div>
+            </div>
+        </div>
+
+    </div>
+</section>
+</body>
+</html>


### PR DESCRIPTION
##Offer Search Feature

### What's done
- GET /offers/search endpoint
- Filters: keyword, location, sector, duration, company
- Empty state UI ("Aucun stage trouvé")
- Responsive frontend with Thymeleaf
- JPA Query with fuzzy matching

### Subtasks completed
- [x] Create backend endpoint /offers/search
- [x] Display search results on the frontend
- [x] Handle the "no results" case
- [x] Design the search offers interface
- [x] Implement filtering logic on the backend