### PR TITLE
feature/uca-10-save-job-offer

### DIFF
--- a/src/main/java/uca/github/org/controllers/DashboardController.java
+++ b/src/main/java/uca/github/org/controllers/DashboardController.java
@@ -40,7 +40,7 @@ public class DashboardController {
         
         long totalApps = applicationRepository.countByApplicant(currentUser);
         long inReview = applicationRepository.countByApplicantAndStatus(currentUser, Application.ApplicationStatus.UNDER_REVIEW);
-        long savedCount = recommendationRepository.countByUser(currentUser);
+        long savedCount = bookmarkRepository.countByUser(currentUser);
         
         Map<String, Object> stats = new HashMap<>();
         stats.put("totalApplications", totalApps);
@@ -50,7 +50,7 @@ public class DashboardController {
         model.addAttribute("stats", stats);
 
         model.addAttribute("applications", applicationRepository.findByApplicantOrderBySubmittedAtDesc(currentUser));
-        model.addAttribute("bookmarks", bookmarkRepository.findByUser(currentUser));
+        model.addAttribute("bookmarks", bookmarkRepository.findByUserOrderByAddedAtDesc(currentUser));
         model.addAttribute("recommendations", recommendationRepository.findByUserOrderByScoreDesc(currentUser));
 
         return "pages/dashboard";

--- a/src/main/java/uca/github/org/controllers/OfferController.java
+++ b/src/main/java/uca/github/org/controllers/OfferController.java
@@ -247,6 +247,30 @@ public class OfferController {
 
         return "redirect:/offers/my";
     }
+    
+    
+    @PostMapping("/offers/save")
+    public String saveOffer(
+            @RequestParam Long id,
+            @AuthenticationPrincipal User currentUser,
+            RedirectAttributes redirectAttributes) {
+
+        if (currentUser == null) {
+            return "redirect:/login";
+        }
+
+        try {
+            offerService.saveOffer(id, currentUser);
+            redirectAttributes.addFlashAttribute("successMessage", "Offre sauvegardée.");
+        } catch (IllegalArgumentException ex) {
+            redirectAttributes.addFlashAttribute("errorMessage", ex.getMessage());
+        } catch (Exception ex) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Impossible de sauvegarder l'offre pour le moment.");
+        }
+
+        return "redirect:/home";
+    }
+
 
 
 

--- a/src/main/java/uca/github/org/controllers/OfferController.java
+++ b/src/main/java/uca/github/org/controllers/OfferController.java
@@ -141,6 +141,22 @@ public class OfferController {
 
         return "pages/offers/edit";
     }
+    
+    @GetMapping("/bookmarks")
+    public String savedOffers(
+            @AuthenticationPrincipal User currentUser,
+            Model model) {
+
+        if (currentUser == null) {
+            return "redirect:/login";
+        }
+
+        model.addAttribute("user", currentUser);
+        model.addAttribute("bookmarks", offerService.getSavedOffers(currentUser));
+
+        return "pages/offers/saved";
+    }
+
 
 
 

--- a/src/main/java/uca/github/org/controllers/OfferController.java
+++ b/src/main/java/uca/github/org/controllers/OfferController.java
@@ -270,6 +270,30 @@ public class OfferController {
 
         return "redirect:/home";
     }
+    
+    
+    @PostMapping("/offers/unsave")
+    public String removeSavedOffer(
+            @RequestParam Long id,
+            @AuthenticationPrincipal User currentUser,
+            RedirectAttributes redirectAttributes) {
+
+        if (currentUser == null) {
+            return "redirect:/login";
+        }
+
+        try {
+            offerService.removeSavedOffer(id, currentUser);
+            redirectAttributes.addFlashAttribute("successMessage", "Offre retirée des sauvegardes.");
+        } catch (IllegalArgumentException ex) {
+            redirectAttributes.addFlashAttribute("errorMessage", ex.getMessage());
+        } catch (Exception ex) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Impossible de retirer l'offre pour le moment.");
+        }
+
+        return "redirect:/bookmarks";
+    }
+
 
 
 

--- a/src/main/java/uca/github/org/models/Bookmark.java
+++ b/src/main/java/uca/github/org/models/Bookmark.java
@@ -6,7 +6,11 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "bookmarks")
+@Table(name = "bookmarks",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_bookmark_user_internship",
+        columnNames = {"user_id", "internship_id"}
+    ))
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/uca/github/org/repositories/BookmarkRepository.java
+++ b/src/main/java/uca/github/org/repositories/BookmarkRepository.java
@@ -21,5 +21,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     boolean existsByUserAndInternship(User user, Internship internship);
 
     Optional<Bookmark> findByUserAndInternship(User user, Internship internship);
+    
+    List<Bookmark> findByUserOrderByAddedAtDesc(User user);
 
 }

--- a/src/main/java/uca/github/org/repositories/BookmarkRepository.java
+++ b/src/main/java/uca/github/org/repositories/BookmarkRepository.java
@@ -1,14 +1,25 @@
 package uca.github.org.repositories;
 
-import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import uca.github.org.models.Bookmark;
 import uca.github.org.models.User;
+import uca.github.org.models.Internship;
+
+import java.util.List;
+import java.util.Optional;
+
+
 
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     long countByUser(User user);
     List<Bookmark> findByUser(User user);
+    
+    boolean existsByUserAndInternship(User user, Internship internship);
+
+    Optional<Bookmark> findByUserAndInternship(User user, Internship internship);
+
 }

--- a/src/main/java/uca/github/org/services/OfferService.java
+++ b/src/main/java/uca/github/org/services/OfferService.java
@@ -16,6 +16,9 @@ public interface OfferService {
     void deleteOffer(Long id, User currentUser);
     
     List<Bookmark> getSavedOffers(User currentUser);
+    
+    Bookmark saveOffer(Long offerId, User currentUser);
+
 
 
 }

--- a/src/main/java/uca/github/org/services/OfferService.java
+++ b/src/main/java/uca/github/org/services/OfferService.java
@@ -4,6 +4,9 @@ import uca.github.org.forms.OfferEditForm;
 import uca.github.org.forms.OfferPublicationForm;
 import uca.github.org.models.Internship;
 import uca.github.org.models.User;
+import uca.github.org.models.Bookmark;
+
+import java.util.List;
 
 public interface OfferService {
     Internship publishOffer(OfferPublicationForm form, User poster);
@@ -11,5 +14,8 @@ public interface OfferService {
     Internship updateOffer(OfferEditForm form, User currentUser);
     
     void deleteOffer(Long id, User currentUser);
+    
+    List<Bookmark> getSavedOffers(User currentUser);
+
 
 }

--- a/src/main/java/uca/github/org/services/OfferService.java
+++ b/src/main/java/uca/github/org/services/OfferService.java
@@ -18,6 +18,9 @@ public interface OfferService {
     List<Bookmark> getSavedOffers(User currentUser);
     
     Bookmark saveOffer(Long offerId, User currentUser);
+    
+    void removeSavedOffer(Long offerId, User currentUser);
+
 
 
 

--- a/src/main/java/uca/github/org/services/OfferServiceImpl.java
+++ b/src/main/java/uca/github/org/services/OfferServiceImpl.java
@@ -126,6 +126,18 @@ public class OfferServiceImpl implements OfferService {
                                 .build()
                 ));
     }
+    
+    @Override
+    public void removeSavedOffer(Long offerId, User currentUser) {
+        Internship offer = internshipRepository.findById(offerId)
+                .orElseThrow(() -> new IllegalArgumentException("Offre introuvable."));
+
+        Bookmark bookmark = bookmarkRepository.findByUserAndInternship(currentUser, offer)
+                .orElseThrow(() -> new IllegalArgumentException("Cette offre n'est pas sauvegardée."));
+
+        bookmarkRepository.delete(bookmark);
+    }
+
 
 
 

--- a/src/main/java/uca/github/org/services/OfferServiceImpl.java
+++ b/src/main/java/uca/github/org/services/OfferServiceImpl.java
@@ -108,6 +108,25 @@ public class OfferServiceImpl implements OfferService {
     public List<Bookmark> getSavedOffers(User currentUser) {
         return bookmarkRepository.findByUserOrderByAddedAtDesc(currentUser);
     }
+    
+    @Override
+    public Bookmark saveOffer(Long offerId, User currentUser) {
+        Internship offer = internshipRepository.findById(offerId)
+                .orElseThrow(() -> new IllegalArgumentException("Offre introuvable."));
+
+        if (offer.getStatus() != Internship.InternshipStatus.ACTIVE) {
+            throw new IllegalArgumentException("Cette offre n'est plus disponible.");
+        }
+
+        return bookmarkRepository.findByUserAndInternship(currentUser, offer)
+                .orElseGet(() -> bookmarkRepository.save(
+                        Bookmark.builder()
+                                .user(currentUser)
+                                .internship(offer)
+                                .build()
+                ));
+    }
+
 
 
 }

--- a/src/main/java/uca/github/org/services/OfferServiceImpl.java
+++ b/src/main/java/uca/github/org/services/OfferServiceImpl.java
@@ -11,6 +11,11 @@ import uca.github.org.forms.OfferPublicationForm;
 import uca.github.org.models.Internship;
 import uca.github.org.models.User;
 import uca.github.org.repositories.InternshipRepository;
+import uca.github.org.models.Bookmark;
+import uca.github.org.repositories.BookmarkRepository;
+
+import java.util.List;
+
 
 
 
@@ -20,6 +25,8 @@ import uca.github.org.repositories.InternshipRepository;
 public class OfferServiceImpl implements OfferService {
 
     private final InternshipRepository internshipRepository;
+    private final BookmarkRepository bookmarkRepository;
+
 
     @Override
     public Internship publishOffer(OfferPublicationForm form, User poster) {
@@ -95,6 +102,11 @@ public class OfferServiceImpl implements OfferService {
 
         offer.setStatus(Internship.InternshipStatus.ARCHIVED);
         internshipRepository.save(offer);
+    }
+    
+    @Override
+    public List<Bookmark> getSavedOffers(User currentUser) {
+        return bookmarkRepository.findByUserOrderByAddedAtDesc(currentUser);
     }
 
 

--- a/src/main/resources/templates/pages/home.html
+++ b/src/main/resources/templates/pages/home.html
@@ -117,6 +117,15 @@
 
 <main class="container-xl py-5">
 
+<div th:if="${successMessage}" class="alert alert-success">
+  <span th:text="${successMessage}"></span>
+</div>
+
+<div th:if="${errorMessage}" class="alert alert-danger">
+  <span th:text="${errorMessage}"></span>
+</div>
+
+
   <!-- HEADER -->
   <section class="mb-5">
     <div class="row align-items-center g-4">

--- a/src/main/resources/templates/pages/home.html
+++ b/src/main/resources/templates/pages/home.html
@@ -352,8 +352,9 @@
                 Se connecter pour postuler
               </a>
 
-              <form th:action="@{'/bookmarks/' + ${internship.id}}" method="post" class="m-0" sec:authorize="isAuthenticated()">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+              <form th:action="@{/offers/save}" method="post" class="m-0" sec:authorize="isAuthenticated()">
+                   <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                   <input type="hidden" name="id" th:value="${internship.id}">
 
                 <button type="submit" class="btn btn-outline-primary btn-sm rounded-pill px-4">
                   <i class="bi bi-bookmark me-1"></i>

--- a/src/main/resources/templates/pages/offers/saved.html
+++ b/src/main/resources/templates/pages/offers/saved.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Offres sauvegardées</title>
+    <link rel="stylesheet" th:href="@{/assets/css/main.css}">
+    <script th:src="@{/assets/js/main.js}" defer></script>
+</head>
+
+<body class="bg-light">
+
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top py-2">
+  <div class="container-xl">
+
+    <a class="navbar-brand fw-bold fs-3" th:href="@{/home}">
+      InternConnect
+    </a>
+
+    <button class="navbar-toggler"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#mainNavbar"
+            aria-controls="mainNavbar"
+            aria-expanded="false"
+            aria-label="Basculer la navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse" id="mainNavbar">
+
+      <ul class="navbar-nav ms-lg-4 me-auto mb-2 mb-lg-0">
+
+        <li class="nav-item">
+          <a class="nav-link" th:href="@{/home}">
+            <i class="bi bi-house-door me-1"></i>
+            Accueil
+          </a>
+        </li>
+
+        <li class="nav-item">
+          <a class="nav-link active" th:href="@{/dashboard}">
+            <i class="bi bi-speedometer2 me-1"></i>
+            Tableau de bord
+          </a>
+        </li>
+       </ul>
+       <div class="d-flex align-items-center gap-3">
+
+        <a th:href="@{/profile}"
+           class="btn btn-light btn-sm rounded-pill d-flex align-items-center gap-2"
+           title="Profil">
+
+          <span class="avatar-box avatar-box-light" th:text="${user != null && user.firstName != null && user.lastName != null}
+                ? ${#strings.substring(user.firstName,0,1) + #strings.substring(user.lastName,0,1)} : '??'">
+            AM
+          </span>
+
+          <span class="d-none d-md-inline fw-semibold" th:text="${user != null && user.firstName != null ? user.firstName + ' ' + user.lastName : 'Utilisateur'}"></span>
+        </a>
+
+        <form th:action="@{/logout}" method="post" class="m-0">
+          <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+
+          <button type="submit"
+                  class="btn btn-outline-light btn-sm rounded-pill"
+                  title="Déconnexion">
+            <i class="bi bi-box-arrow-right me-1"></i>
+            <span class="d-none d-md-inline">Déconnexion</span>
+          </button>
+        </form>
+
+      </div>
+    </div>
+  </div>
+</nav>
+
+<main class="container py-5">
+
+    <div th:if="${successMessage}" class="alert alert-success">
+        <span th:text="${successMessage}"></span>
+    </div>
+
+    <div th:if="${errorMessage}" class="alert alert-danger">
+        <span th:text="${errorMessage}"></span>
+    </div>
+
+    <div class="mb-4">
+        <h1 class="fw-bold">Offres sauvegardées</h1>
+        <p class="text-muted">Retrouvez ici les offres que vous souhaitez consulter plus tard.</p>
+    </div>
+
+    <div class="card border-0 shadow-sm">
+        <div class="card-body">
+
+            <div th:if="${#lists.isEmpty(bookmarks)}" class="text-center text-muted py-5">
+                Aucune offre sauvegardée pour le moment.
+            </div>
+
+            <div class="list-group" th:if="${!#lists.isEmpty(bookmarks)}">
+                <div class="list-group-item" th:each="bookmark : ${bookmarks}">
+
+                    <h5 class="fw-bold mb-1"
+                        th:text="${bookmark.internship != null ? bookmark.internship.title : 'Offre'}">
+                        Titre offre
+                    </h5>
+
+                    <p class="text-muted mb-1">
+                        <span th:text="${bookmark.internship != null ? bookmark.internship.company : 'Entreprise'}">
+                            Entreprise
+                        </span>
+                        ·
+                        <span th:text="${bookmark.internship != null ? bookmark.internship.location : 'Localisation'}">
+                            Localisation
+                        </span>
+                    </p>
+
+                    <small class="text-muted">
+                        Sauvegardée le
+                        <span th:text="${bookmark.addedAt != null ? #temporals.format(bookmark.addedAt, 'dd/MM/yyyy') : 'date inconnue'}">
+                            04/05/2026
+                        </span>
+                    </small>
+
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+</main>
+
+</body>
+</html>

--- a/src/main/resources/templates/pages/offers/saved.html
+++ b/src/main/resources/templates/pages/offers/saved.html
@@ -120,6 +120,27 @@
                             04/05/2026
                         </span>
                     </small>
+                    
+                    <div class="mt-3 d-flex gap-2">
+                         <a th:if="${bookmark.internship != null}"
+                            th:href="@{'/internships/' + ${bookmark.internship.id}}"
+                            class="btn btn-outline-primary btn-sm">
+                              Voir l'offre
+                         </a>
+
+                         <form th:if="${bookmark.internship != null}"
+                               th:action="@{/offers/unsave}"
+                               method="post"
+                               class="m-0">
+                           <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                           <input type="hidden" name="id" th:value="${bookmark.internship.id}">
+
+                          <button type="submit" class="btn btn-outline-danger btn-sm">
+                             Retirer
+                          </button>
+                        </form>
+                    </div>
+                    
 
                 </div>
             </div>

--- a/src/test/java/uca/github/org/OfferServiceTest.java
+++ b/src/test/java/uca/github/org/OfferServiceTest.java
@@ -3,6 +3,9 @@ package uca.github.org;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 
 import java.util.Optional;
 
@@ -16,12 +19,19 @@ import uca.github.org.models.Internship;
 import uca.github.org.models.User;
 import uca.github.org.repositories.InternshipRepository;
 import uca.github.org.services.OfferServiceImpl;
+import uca.github.org.models.Bookmark;
+import uca.github.org.repositories.BookmarkRepository;
+
 
 @ExtendWith(MockitoExtension.class)
 class OfferServiceTest {
 
     @Mock
     private InternshipRepository internshipRepository;
+    
+    @Mock
+    private BookmarkRepository bookmarkRepository;
+
 
     @InjectMocks
     private OfferServiceImpl offerService;
@@ -46,4 +56,88 @@ class OfferServiceTest {
         assertEquals(Internship.InternshipStatus.ARCHIVED, offer.getStatus());
         verify(internshipRepository).save(offer);
     }
+    
+    @Test
+    void saveOffer_ShouldCreateBookmark_WhenOfferIsActiveAndNotSaved() {
+        User user = User.builder()
+                .id(1L)
+                .role(User.Role.USER)
+                .build();
+
+        Internship offer = Internship.builder()
+                .id(10L)
+                .status(Internship.InternshipStatus.ACTIVE)
+                .build();
+
+        Bookmark savedBookmark = Bookmark.builder()
+                .id(100L)
+                .user(user)
+                .internship(offer)
+                .build();
+
+        when(internshipRepository.findById(10L)).thenReturn(Optional.of(offer));
+        when(bookmarkRepository.findByUserAndInternship(user, offer)).thenReturn(Optional.empty());
+        when(bookmarkRepository.save(any(Bookmark.class))).thenReturn(savedBookmark);
+
+        Bookmark result = offerService.saveOffer(10L, user);
+
+        assertSame(savedBookmark, result);
+        verify(bookmarkRepository).save(any(Bookmark.class));
+    }
+    
+    @Test
+    void saveOffer_ShouldReturnExistingBookmark_WhenAlreadySaved() {
+        User user = User.builder()
+                .id(1L)
+                .role(User.Role.USER)
+                .build();
+
+        Internship offer = Internship.builder()
+                .id(10L)
+                .status(Internship.InternshipStatus.ACTIVE)
+                .build();
+
+        Bookmark existingBookmark = Bookmark.builder()
+                .id(100L)
+                .user(user)
+                .internship(offer)
+                .build();
+
+        when(internshipRepository.findById(10L)).thenReturn(Optional.of(offer));
+        when(bookmarkRepository.findByUserAndInternship(user, offer)).thenReturn(Optional.of(existingBookmark));
+
+        Bookmark result = offerService.saveOffer(10L, user);
+
+        assertSame(existingBookmark, result);
+        verify(bookmarkRepository, never()).save(any(Bookmark.class));
+    }
+    
+    @Test
+    void removeSavedOffer_ShouldDeleteBookmark_WhenBookmarkExists() {
+        User user = User.builder()
+                .id(1L)
+                .role(User.Role.USER)
+                .build();
+
+        Internship offer = Internship.builder()
+                .id(10L)
+                .status(Internship.InternshipStatus.ACTIVE)
+                .build();
+
+        Bookmark bookmark = Bookmark.builder()
+                .id(100L)
+                .user(user)
+                .internship(offer)
+                .build();
+
+        when(internshipRepository.findById(10L)).thenReturn(Optional.of(offer));
+        when(bookmarkRepository.findByUserAndInternship(user, offer)).thenReturn(Optional.of(bookmark));
+
+        offerService.removeSavedOffer(10L, user);
+
+        verify(bookmarkRepository).delete(bookmark);
+    }
+
+
+
 }


### PR DESCRIPTION
# Pull Request: feat(UCA-10): Implement Job Offer Save Feature

## 📌 Description

This Pull Request implements **User Story UCA-10**, allowing users to save job offers and access them later from their personal dashboard.

---

## 🚀 Features Implemented

* Add UI to save a job offer (from list and detail view)
* Update data model to support saved job offers
* Display saved job offers in the user dashboard
* Create backend endpoint `POST /offers/save`
* Implement removal of saved job offers
* Add unit and integration tests

---

## 🧩 Technical Details

* Added association between **User** and **SavedOffers** in the database
* Secured endpoints for saving and removing offers
* Error handling implemented for:

  * Non-existent offer
  * Already saved offer
  * Unauthorized access
* Improved user experience with visual feedback (save/unsave actions)

---

## 📦 Related Commits

* feat(UCA-119): design job offer save interface
* feat(UCA-120): update data model for saved job offers
* feat(UCA-121): display saved job offers in user dashboard
* feat(UCA-122): create /offers/save backend endpoint
* feat(UCA-123): handle removal of saved job offers
* test(UCA-124): add tests for job offer save feature

---

## 🧪 Testing

* Unit tests for save/unsave logic
* Integration tests for API endpoints
* Verified:

  * Saving a job offer
  * Removing a saved offer
  * Retrieving saved offers list

---

## ⚠️ Review Notes

* Check data model consistency
* Test edge cases (duplicate save, removing non-existent saved offer)
* Verify endpoint security (authentication required)
* Validate frontend UX (save/unsave behavior)

---

Fixes #12 