### PR TITLE
Add poster applicant filtering for offers

### DIFF
--- a/src/main/java/uca/github/org/configuration/InternConnectSecurityConfiguration.java
+++ b/src/main/java/uca/github/org/configuration/InternConnectSecurityConfiguration.java
@@ -27,7 +27,7 @@ public class InternConnectSecurityConfiguration {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(requests -> requests
-                .requestMatchers("/", "/index", "/index.html", "/home", "/home.html", "/register", "/css/**", "/js/**" , "/assets/**", "/applications/**" )
+                .requestMatchers("/", "/index", "/index.html", "/home", "/home.html", "/register", "/css/**", "/js/**" , "/assets/**" )
                 .permitAll()
                 .anyRequest().authenticated())
                 .formLogin(form -> form.loginPage("/login").defaultSuccessUrl("/dashboard" , true).permitAll())

--- a/src/main/java/uca/github/org/controllers/ApplicationController.java
+++ b/src/main/java/uca/github/org/controllers/ApplicationController.java
@@ -2,6 +2,7 @@ package uca.github.org.controllers;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -9,6 +10,8 @@ import org.springframework.web.bind.annotation.*;
 import uca.github.org.models.Application;
 import uca.github.org.models.User;
 import uca.github.org.services.ApplicationService;
+
+import java.time.LocalDate;
 import java.util.*;
 
 @Controller
@@ -17,6 +20,36 @@ import java.util.*;
 public class ApplicationController {
 
     private final ApplicationService applicationService;
+
+    @GetMapping("/offers/{offerId}")
+    public String getOfferApplications(
+            @PathVariable Long offerId,
+            @RequestParam(required = false) String applicantName,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate submittedDate,
+            @AuthenticationPrincipal User currentUser,
+            Model model) {
+
+        if (currentUser == null) return "redirect:/login";
+
+        try {
+            List<Application> applications = applicationService.getOfferApplications(
+                    offerId,
+                    currentUser,
+                    applicantName,
+                    submittedDate);
+
+            model.addAttribute("applications", applications);
+            model.addAttribute("offerId", offerId);
+            model.addAttribute("applicantName", applicantName);
+            model.addAttribute("submittedDate", submittedDate);
+            model.addAttribute("user", currentUser);
+
+            return "pages/offers/applicants";
+        } catch (IllegalArgumentException | EntityNotFoundException e) {
+            return "redirect:/offers/my";
+        }
+    }
 
     @GetMapping("/status")
     public String getApplicationStatus(

--- a/src/main/java/uca/github/org/repositories/ApplicationRepository.java
+++ b/src/main/java/uca/github/org/repositories/ApplicationRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uca.github.org.models.Application;
+import uca.github.org.models.Internship;
 import uca.github.org.models.User;
 
 @Repository
@@ -13,4 +14,5 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     List<Application> findByApplicantOrderBySubmittedAtDesc(User applicant);
     List<Application>findByApplicantAndStatusOrderBySubmittedAtDesc(
             User applicant, Application.ApplicationStatus status);
+    List<Application> findByInternshipOrderBySubmittedAtDesc(Internship internship);
 }

--- a/src/main/java/uca/github/org/services/ApplicationService.java
+++ b/src/main/java/uca/github/org/services/ApplicationService.java
@@ -2,6 +2,7 @@ package uca.github.org.services;
 
 import uca.github.org.models.Application;
 import uca.github.org.models.User;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.* ;
 
@@ -11,4 +12,9 @@ public interface ApplicationService {
             User user, Application.ApplicationStatus status);
     Application updateApplicationStatus(Long applicationId, Application.ApplicationStatus newStatus);
     Map<Application.ApplicationStatus, Long> getStatusSummary(User user);
+    List<Application> getOfferApplications(
+            Long offerId,
+            User currentUser,
+            String applicantName,
+            LocalDate submittedDate);
 }

--- a/src/main/java/uca/github/org/services/ApplicationServiceImpl.java
+++ b/src/main/java/uca/github/org/services/ApplicationServiceImpl.java
@@ -4,8 +4,12 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uca.github.org.models.Application;
+import uca.github.org.models.Internship;
 import uca.github.org.models.User;
 import uca.github.org.repositories.ApplicationRepository;
+import uca.github.org.repositories.InternshipRepository;
+
+import java.time.LocalDate;
 import java.util.List;
 import java.util.* ;
 
@@ -14,6 +18,7 @@ import java.util.* ;
 public class ApplicationServiceImpl implements ApplicationService {
 
     private final ApplicationRepository applicationRepository;
+    private final InternshipRepository internshipRepository;
 
     @Override
     public List<Application> getUserApplications(User user) {
@@ -45,5 +50,66 @@ public class ApplicationServiceImpl implements ApplicationService {
             summary.put(status, applicationRepository.countByApplicantAndStatus(user, status));
         }
         return summary;
+    }
+
+    @Override
+    public List<Application> getOfferApplications(
+            Long offerId,
+            User currentUser,
+            String applicantName,
+            LocalDate submittedDate) {
+
+        Internship internship = internshipRepository.findById(offerId)
+                .orElseThrow(() -> new EntityNotFoundException("Offer not found: " + offerId));
+
+        if (!canViewOfferApplications(internship, currentUser)) {
+            throw new IllegalArgumentException("Vous n'avez pas le droit de consulter ces candidatures.");
+        }
+
+        String normalizedName = normalize(applicantName);
+
+        return applicationRepository.findByInternshipOrderBySubmittedAtDesc(internship).stream()
+                .filter(application -> matchesApplicantName(application, normalizedName))
+                .filter(application -> matchesSubmittedDate(application, submittedDate))
+                .toList();
+    }
+
+    private boolean canViewOfferApplications(Internship internship, User currentUser) {
+        if (currentUser == null) {
+            return false;
+        }
+
+        if (currentUser.getRole() == User.Role.ADMIN) {
+            return true;
+        }
+
+        return internship.getPoster() != null
+                && internship.getPoster().getId() != null
+                && internship.getPoster().getId().equals(currentUser.getId());
+    }
+
+    private boolean matchesApplicantName(Application application, String applicantName) {
+        if (applicantName.isBlank()) {
+            return true;
+        }
+
+        User applicant = application.getApplicant();
+        if (applicant == null) {
+            return false;
+        }
+
+        String fullName = normalize(applicant.getFirstName() + " " + applicant.getLastName());
+        String reversedName = normalize(applicant.getLastName() + " " + applicant.getFirstName());
+        return fullName.contains(applicantName) || reversedName.contains(applicantName);
+    }
+
+    private boolean matchesSubmittedDate(Application application, LocalDate submittedDate) {
+        return submittedDate == null
+                || application.getSubmittedAt() != null
+                && application.getSubmittedAt().toLocalDate().equals(submittedDate);
+    }
+
+    private String normalize(String value) {
+        return value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/resources/templates/pages/offers/applicants.html
+++ b/src/main/resources/templates/pages/offers/applicants.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Candidats de l'offre</title>
+    <link rel="stylesheet" th:href="@{/assets/css/main.css}">
+    <script th:src="@{/assets/js/main.js}" defer></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+</head>
+
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top py-2">
+    <div class="container-xl">
+        <a class="navbar-brand fw-bold fs-3" th:href="@{/home}">InternConnect</a>
+
+        <button class="navbar-toggler"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#mainNavbar"
+                aria-controls="mainNavbar"
+                aria-expanded="false"
+                aria-label="Basculer la navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="mainNavbar">
+            <ul class="navbar-nav ms-lg-4 me-auto mb-2 mb-lg-0">
+                <li class="nav-item">
+                    <a class="nav-link" th:href="@{/home}">
+                        <i class="bi bi-house-door me-1"></i>
+                        Accueil
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link active" th:href="@{/offers/my}">
+                        <i class="bi bi-list-task me-1"></i>
+                        Mes offres
+                    </a>
+                </li>
+            </ul>
+
+            <div class="d-flex align-items-center gap-3">
+                <a th:href="@{/offers/my}" class="btn btn-outline-light btn-sm rounded-pill">
+                    <i class="bi bi-arrow-left me-1"></i>
+                    Retour
+                </a>
+
+                <a th:href="@{/profile}"
+                   class="btn btn-light btn-sm rounded-pill d-flex align-items-center gap-2"
+                   title="Profil">
+                    <span class="avatar-box avatar-box-light"
+                          th:text="${user != null && user.firstName != null && user.lastName != null}
+                          ? ${#strings.substring(user.firstName,0,1) + #strings.substring(user.lastName,0,1)}
+                          : '??'">
+                        AZ
+                    </span>
+                    <span class="d-none d-md-inline fw-semibold"
+                          th:text="${user != null && user.firstName != null
+                          ? user.firstName + ' ' + user.lastName
+                          : 'Utilisateur'}">
+                        Utilisateur
+                    </span>
+                </a>
+
+                <form th:action="@{/logout}" method="post" class="m-0">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <button type="submit" class="btn btn-outline-light btn-sm rounded-pill" title="Deconnexion">
+                        <i class="bi bi-box-arrow-right me-1"></i>
+                        <span class="d-none d-md-inline">Deconnexion</span>
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</nav>
+
+<main class="container-xl py-5">
+    <section class="mb-4">
+        <h1 class="display-6 fw-bold mb-1">Candidats de l'offre</h1>
+        <p class="text-secondary mb-0">Consultez et filtrez les etudiants qui ont postule a cette offre.</p>
+    </section>
+
+    <form th:action="@{/applications/offers/{id}(id=${offerId})}" method="get" class="card border-0 shadow-sm mb-4">
+        <div class="card-body">
+            <div class="row g-3 align-items-end">
+                <div class="col-md-6">
+                    <label for="applicantName" class="form-label">Nom du candidat</label>
+                    <input id="applicantName"
+                           name="applicantName"
+                           type="search"
+                           class="form-control"
+                           th:value="${applicantName}"
+                           placeholder="Rechercher par prenom ou nom">
+                </div>
+
+                <div class="col-md-4">
+                    <label for="submittedDate" class="form-label">Date de candidature</label>
+                    <input id="submittedDate"
+                           name="submittedDate"
+                           type="date"
+                           class="form-control"
+                           th:value="${submittedDate}">
+                </div>
+
+                <div class="col-md-2 d-grid">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-funnel me-1"></i>
+                        Filtrer
+                    </button>
+                </div>
+            </div>
+        </div>
+    </form>
+
+    <div th:if="${applications == null or applications.isEmpty()}" class="text-center py-5 text-muted">
+        <i class="bi bi-inbox fs-1 d-block mb-3 opacity-25"></i>
+        <p>Aucune candidature trouvee pour cette offre.</p>
+    </div>
+
+    <div class="card border-0 shadow-sm overflow-hidden" th:unless="${applications == null or applications.isEmpty()}">
+        <div class="table-responsive">
+            <table class="table align-middle mb-0">
+                <thead class="table-light">
+                <tr>
+                    <th>Etudiant</th>
+                    <th>Email</th>
+                    <th>Statut</th>
+                    <th>Date de candidature</th>
+                    <th>CV</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="application : ${applications}">
+                    <td>
+                        <div class="fw-semibold"
+                             th:text="${application.applicant != null
+                             ? application.applicant.firstName + ' ' + application.applicant.lastName
+                             : 'Candidat'}">
+                            Candidat
+                        </div>
+                    </td>
+                    <td th:text="${application.applicant != null ? application.applicant.email : 'Non renseigne'}">
+                        email@example.com
+                    </td>
+                    <td>
+                        <span class="badge px-3 py-2"
+                              th:text="${application.status}"
+                              th:classappend="${application.status.name() == 'ACCEPTED'} ? ' bg-success'
+                              : (${application.status.name() == 'REJECTED'} ? ' bg-danger'
+                              : (${application.status.name() == 'UNDER_REVIEW'} ? ' bg-info'
+                              : ' bg-warning text-dark'))">
+                            SUBMITTED
+                        </span>
+                    </td>
+                    <td th:text="${application.submittedAt != null ? #temporals.format(application.submittedAt, 'dd MMM yyyy HH:mm') : 'Date inconnue'}">
+                        01 Jan 2026
+                    </td>
+                    <td th:text="${application.resumeFile != null && !application.resumeFile.isBlank() ? application.resumeFile : 'Non fourni'}">
+                        cv.pdf
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</main>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/offers/my-offers.html
+++ b/src/main/resources/templates/pages/offers/my-offers.html
@@ -142,6 +142,10 @@
                         </div>
 
                         <div class="d-flex gap-2">
+                            <a th:href="@{/applications/offers/{id}(id=${offer.id})}" class="btn btn-outline-secondary btn-sm">
+                               Candidats
+                            </a>
+
                             <a th:href="@{/offers/edit/{id}(id=${offer.id})}" class="btn btn-outline-primary btn-sm">
                                Modifier
                             </a>

--- a/src/test/java/uca/github/org/ApplicationServiceTest.java
+++ b/src/test/java/uca/github/org/ApplicationServiceTest.java
@@ -7,10 +7,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uca.github.org.models.Application;
+import uca.github.org.models.Internship;
 import uca.github.org.models.User;
 import uca.github.org.repositories.ApplicationRepository;
+import uca.github.org.repositories.InternshipRepository;
 import uca.github.org.services.ApplicationServiceImpl;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,6 +27,9 @@ class ApplicationServiceTest {
 
     @Mock
     private ApplicationRepository applicationRepository;
+
+    @Mock
+    private InternshipRepository internshipRepository;
 
     @InjectMocks
     private ApplicationServiceImpl applicationService;
@@ -188,5 +195,121 @@ class ApplicationServiceTest {
         assertThat(summary).containsKey(Application.ApplicationStatus.UNDER_REVIEW);
         assertThat(summary.get(Application.ApplicationStatus.SUBMITTED)).isEqualTo(3L);
         assertThat(summary.get(Application.ApplicationStatus.ACCEPTED)).isEqualTo(1L);
+    }
+
+    // -------------------------------------------------------
+    // getOfferApplications
+    // -------------------------------------------------------
+
+    @Test
+    void getOfferApplications_shouldReturnApplicantsForOfferOwner() {
+        User poster = User.builder().id(1L).role(User.Role.POSTER).build();
+        Internship internship = Internship.builder().id(10L).poster(poster).build();
+        Application firstApplication = Application.builder()
+                .applicant(User.builder().firstName("Sara").lastName("Amrani").build())
+                .internship(internship)
+                .submittedAt(LocalDateTime.of(2026, 5, 10, 9, 30))
+                .build();
+        Application secondApplication = Application.builder()
+                .applicant(User.builder().firstName("Youssef").lastName("Bennani").build())
+                .internship(internship)
+                .submittedAt(LocalDateTime.of(2026, 5, 11, 14, 0))
+                .build();
+
+        when(internshipRepository.findById(10L)).thenReturn(Optional.of(internship));
+        when(applicationRepository.findByInternshipOrderBySubmittedAtDesc(internship))
+                .thenReturn(List.of(secondApplication, firstApplication));
+
+        List<Application> result = applicationService.getOfferApplications(10L, poster, null, null);
+
+        assertThat(result).containsExactly(secondApplication, firstApplication);
+        verify(applicationRepository).findByInternshipOrderBySubmittedAtDesc(internship);
+    }
+
+    @Test
+    void getOfferApplications_shouldFilterApplicantsByName() {
+        User poster = User.builder().id(1L).role(User.Role.POSTER).build();
+        Internship internship = Internship.builder().id(10L).poster(poster).build();
+        Application matchingApplication = Application.builder()
+                .applicant(User.builder().firstName("Sara").lastName("Amrani").build())
+                .internship(internship)
+                .submittedAt(LocalDateTime.of(2026, 5, 10, 9, 30))
+                .build();
+        Application otherApplication = Application.builder()
+                .applicant(User.builder().firstName("Youssef").lastName("Bennani").build())
+                .internship(internship)
+                .submittedAt(LocalDateTime.of(2026, 5, 11, 14, 0))
+                .build();
+
+        when(internshipRepository.findById(10L)).thenReturn(Optional.of(internship));
+        when(applicationRepository.findByInternshipOrderBySubmittedAtDesc(internship))
+                .thenReturn(List.of(otherApplication, matchingApplication));
+
+        List<Application> result = applicationService.getOfferApplications(10L, poster, "sara", null);
+
+        assertThat(result).containsExactly(matchingApplication);
+    }
+
+    @Test
+    void getOfferApplications_shouldFilterApplicantsBySubmittedDate() {
+        User poster = User.builder().id(1L).role(User.Role.POSTER).build();
+        Internship internship = Internship.builder().id(10L).poster(poster).build();
+        Application matchingApplication = Application.builder()
+                .applicant(User.builder().firstName("Sara").lastName("Amrani").build())
+                .internship(internship)
+                .submittedAt(LocalDateTime.of(2026, 5, 10, 9, 30))
+                .build();
+        Application otherApplication = Application.builder()
+                .applicant(User.builder().firstName("Youssef").lastName("Bennani").build())
+                .internship(internship)
+                .submittedAt(LocalDateTime.of(2026, 5, 11, 14, 0))
+                .build();
+
+        when(internshipRepository.findById(10L)).thenReturn(Optional.of(internship));
+        when(applicationRepository.findByInternshipOrderBySubmittedAtDesc(internship))
+                .thenReturn(List.of(otherApplication, matchingApplication));
+
+        List<Application> result = applicationService.getOfferApplications(
+                10L,
+                poster,
+                null,
+                LocalDate.of(2026, 5, 10));
+
+        assertThat(result).containsExactly(matchingApplication);
+    }
+
+    @Test
+    void getOfferApplications_shouldAllowAdminToViewAnyOffer() {
+        User poster = User.builder().id(1L).role(User.Role.POSTER).build();
+        User admin = User.builder().id(2L).role(User.Role.ADMIN).build();
+        Internship internship = Internship.builder().id(10L).poster(poster).build();
+        Application application = Application.builder()
+                .applicant(User.builder().firstName("Sara").lastName("Amrani").build())
+                .internship(internship)
+                .submittedAt(LocalDateTime.of(2026, 5, 10, 9, 30))
+                .build();
+
+        when(internshipRepository.findById(10L)).thenReturn(Optional.of(internship));
+        when(applicationRepository.findByInternshipOrderBySubmittedAtDesc(internship))
+                .thenReturn(List.of(application));
+
+        List<Application> result = applicationService.getOfferApplications(10L, admin, null, null);
+
+        assertThat(result).containsExactly(application);
+    }
+
+    @Test
+    void getOfferApplications_shouldRejectUserWhoDoesNotOwnOffer() {
+        User poster = User.builder().id(1L).role(User.Role.POSTER).build();
+        User otherUser = User.builder().id(2L).role(User.Role.USER).build();
+        Internship internship = Internship.builder().id(10L).poster(poster).build();
+
+        when(internshipRepository.findById(10L)).thenReturn(Optional.of(internship));
+
+        assertThatThrownBy(() -> applicationService.getOfferApplications(10L, otherUser, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("droit");
+
+        verify(applicationRepository, never()).findByInternshipOrderBySubmittedAtDesc(any());
     }
 }


### PR DESCRIPTION
This pull request adds the ability for an offer poster to view the students who applied to one of their internship offers.

It introduces a protected applicants page for each offer, with filtering by applicant name and application date. The access is restricted so that only the offer owner or an admin can view the applications.

## Changes

- Added a new endpoint to display applications for a specific offer.
- Added service logic to retrieve applications linked to an internship offer.
- Added authorization checks so only:
  - the poster who owns the offer
  - an admin
  can view the offer applicants.
- Added filters for:
  - applicant first name / last name
  - application submission date
- Added a new Thymeleaf page: `pages/offers/applicants.html`.
- Added a “Candidats” button in `my-offers.html` to access the applicants of each offer.
- Removed `/applications/**` from public security matchers so application-related pages require authentication.

## Files Updated

- `InternConnectSecurityConfiguration.java`
- `ApplicationController.java`
- `ApplicationRepository.java`
- `ApplicationService.java`
- `ApplicationServiceImpl.java`
- `applicants.html`
- `my-offers.html`

## Test Scenarios

- Poster can access the candidates list for their own offer.
- Poster cannot access candidates of another poster’s offer.
- Admin can access candidates of any offer.
- Unauthenticated user is redirected to login.
- Applicants can be filtered by name.
- Applicants can be filtered by submitted date.
- Empty result displays a clear “Aucune candidature trouvée” message.

## Notes

This feature supports the poster workflow by allowing recruiters/posters to review students who applied to their internship offers directly from the “Mes offres” page.