### PR TITLE
Feature/uca-61-manage-admin-poster-candidate-roles

### DIFF
--- a/src/main/java/uca/github/org/controllers/RoleManagementController.java
+++ b/src/main/java/uca/github/org/controllers/RoleManagementController.java
@@ -20,12 +20,12 @@ import java.util.Set;
 
 @Controller
 @RequiredArgsConstructor
-@PreAuthorize("hasRole('ADMIN')")
 public class RoleManagementController {
 
     private final RoleManagementService roleManagementService;
 
     @GetMapping("/roles")
+    @PreAuthorize("(hasAuthority('MANAGE_ROLES') and hasAuthority('VIEW_USERS')) or hasRole('ADMIN')")
     public String roles(Model model, @AuthenticationPrincipal User currentUser) {
         model.addAttribute("user", currentUser);
         model.addAttribute("roles", roleManagementService.getAllRoles());
@@ -35,6 +35,7 @@ public class RoleManagementController {
     }
 
     @PostMapping("/roles/users/assign")
+    @PreAuthorize("hasAuthority('ASSIGN_ROLES') or hasRole('ADMIN')")
     public String assignRole(
             @RequestParam Long userId,
             @RequestParam Long roleId,
@@ -46,6 +47,7 @@ public class RoleManagementController {
     }
 
     @PostMapping("/roles/users/{userId}/role")
+    @PreAuthorize("hasAuthority('ASSIGN_ROLES') or hasRole('ADMIN')")
     public String assignRoleToUser(
             @PathVariable Long userId,
             @RequestParam Long roleId,
@@ -55,6 +57,7 @@ public class RoleManagementController {
     }
 
     @PostMapping("/roles/permissions")
+    @PreAuthorize("hasAuthority('MANAGE_ROLES') or hasRole('ADMIN')")
     public String updatePermissions(
             @RequestParam Long roleId,
             @RequestParam(required = false) Set<Permission> permissions,

--- a/src/main/java/uca/github/org/controllers/RoleManagementController.java
+++ b/src/main/java/uca/github/org/controllers/RoleManagementController.java
@@ -46,6 +46,18 @@ public class RoleManagementController {
         return "redirect:/roles";
     }
 
+    @PostMapping("/roles/users/assign-many")
+    @PreAuthorize("hasAuthority('ASSIGN_ROLES') or hasRole('ADMIN')")
+    public String assignRoles(
+            @RequestParam Long userId,
+            @RequestParam(required = false) Set<Long> roleIds,
+            RedirectAttributes redirectAttributes) {
+
+        roleManagementService.assignRoles(userId, roleIds == null ? Set.of() : new LinkedHashSet<>(roleIds));
+        redirectAttributes.addFlashAttribute("successMessage", "Roles utilisateur mis a jour.");
+        return "redirect:/roles";
+    }
+
     @PostMapping("/roles/users/{userId}/role")
     @PreAuthorize("hasAuthority('ASSIGN_ROLES') or hasRole('ADMIN')")
     public String assignRoleToUser(

--- a/src/main/java/uca/github/org/models/Permission.java
+++ b/src/main/java/uca/github/org/models/Permission.java
@@ -1,12 +1,28 @@
 package uca.github.org.models;
 
 public enum Permission {
-    MANAGE_ROLES,
-    ASSIGN_ROLES,
-    VIEW_USERS,
-    PUBLISH_OFFERS,
-    MANAGE_OWN_OFFERS,
-    MANAGE_ANY_OFFER,
-    VIEW_OFFER_APPLICATIONS,
-    APPLY_TO_OFFERS
+    MANAGE_ROLES("Gestion des roles", "Modifier les permissions associees aux roles."),
+    ASSIGN_ROLES("Affectation des roles", "Attribuer des roles aux utilisateurs."),
+    VIEW_USERS("Consultation utilisateurs", "Consulter les utilisateurs inscrits."),
+    PUBLISH_OFFERS("Publication d'offres", "Publier de nouvelles offres de stage."),
+    MANAGE_OWN_OFFERS("Gestion de ses offres", "Modifier et suivre ses propres offres."),
+    MANAGE_ANY_OFFER("Gestion globale des offres", "Administrer toutes les offres publiees."),
+    VIEW_OFFER_APPLICATIONS("Consultation candidatures", "Voir les candidatures liees aux offres."),
+    APPLY_TO_OFFERS("Candidature aux offres", "Postuler aux offres disponibles.");
+
+    private final String label;
+    private final String description;
+
+    Permission(String label, String description) {
+        this.label = label;
+        this.description = description;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getDescription() {
+        return description;
+    }
 }

--- a/src/main/java/uca/github/org/models/Role.java
+++ b/src/main/java/uca/github/org/models/Role.java
@@ -53,4 +53,11 @@ public class Role {
     public String getAuthorityName() {
         return "ROLE_" + name;
     }
+
+    public Set<Permission> getPermissions() {
+        if (permissions == null) {
+            permissions = new LinkedHashSet<>();
+        }
+        return permissions;
+    }
 }

--- a/src/main/java/uca/github/org/models/User.java
+++ b/src/main/java/uca/github/org/models/User.java
@@ -105,11 +105,11 @@ public class User implements UserDetails {
                 ? Stream.empty()
                 : Stream.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
 
-        Stream<SimpleGrantedAuthority> managedRoleAuthorities = assignedRoles.stream()
+        Stream<SimpleGrantedAuthority> managedRoleAuthorities = managedRoles().stream()
                 .filter(Objects::nonNull)
                 .map(managedRole -> new SimpleGrantedAuthority(managedRole.getAuthorityName()));
 
-        Stream<SimpleGrantedAuthority> permissionAuthorities = assignedRoles.stream()
+        Stream<SimpleGrantedAuthority> permissionAuthorities = managedRoles().stream()
                 .filter(Objects::nonNull)
                 .flatMap(managedRole -> managedRole.getPermissions().stream())
                 .map(permission -> new SimpleGrantedAuthority(permission.name()));
@@ -118,6 +118,20 @@ public class User implements UserDetails {
                 .flatMap(authorities -> authorities)
                 .distinct()
                 .toList();
+    }
+
+    public boolean hasAssignedRole(Long roleId) {
+        return roleId != null && managedRoles().stream()
+                .filter(Objects::nonNull)
+                .map(uca.github.org.models.Role::getId)
+                .anyMatch(roleId::equals);
+    }
+
+    private Set<uca.github.org.models.Role> managedRoles() {
+        if (assignedRoles == null) {
+            assignedRoles = new LinkedHashSet<>();
+        }
+        return assignedRoles;
     }
 
     @Override

--- a/src/main/java/uca/github/org/services/AccessControlService.java
+++ b/src/main/java/uca/github/org/services/AccessControlService.java
@@ -15,4 +15,10 @@ public interface AccessControlService {
     boolean canManageOwnOffers(User user);
 
     boolean canViewOfferApplications(User user);
+
+    boolean canManageRoles(User user);
+
+    boolean canAssignRoles(User user);
+
+    boolean canViewUsers(User user);
 }

--- a/src/main/java/uca/github/org/services/AccessControlServiceImpl.java
+++ b/src/main/java/uca/github/org/services/AccessControlServiceImpl.java
@@ -5,6 +5,8 @@ import uca.github.org.models.Permission;
 import uca.github.org.models.Role;
 import uca.github.org.models.User;
 
+import java.util.Set;
+
 @Service
 public class AccessControlServiceImpl implements AccessControlService {
 
@@ -15,7 +17,7 @@ public class AccessControlServiceImpl implements AccessControlService {
         }
 
         return user.getRole() == role
-                || user.getAssignedRoles().stream()
+                || assignedRoles(user).stream()
                 .map(Role::getName)
                 .anyMatch(role.name()::equals);
     }
@@ -26,7 +28,7 @@ public class AccessControlServiceImpl implements AccessControlService {
             return false;
         }
 
-        return user.getAssignedRoles().stream()
+        return assignedRoles(user).stream()
                 .flatMap(role -> role.getPermissions().stream())
                 .anyMatch(permission::equals);
     }
@@ -56,5 +58,27 @@ public class AccessControlServiceImpl implements AccessControlService {
         return hasPermission(user, Permission.VIEW_OFFER_APPLICATIONS)
                 || hasRole(user, User.Role.POSTER)
                 || hasRole(user, User.Role.ADMIN);
+    }
+
+    @Override
+    public boolean canManageRoles(User user) {
+        return hasPermission(user, Permission.MANAGE_ROLES)
+                || hasRole(user, User.Role.ADMIN);
+    }
+
+    @Override
+    public boolean canAssignRoles(User user) {
+        return hasPermission(user, Permission.ASSIGN_ROLES)
+                || hasRole(user, User.Role.ADMIN);
+    }
+
+    @Override
+    public boolean canViewUsers(User user) {
+        return hasPermission(user, Permission.VIEW_USERS)
+                || hasRole(user, User.Role.ADMIN);
+    }
+
+    private Set<Role> assignedRoles(User user) {
+        return user.getAssignedRoles() == null ? Set.of() : user.getAssignedRoles();
     }
 }

--- a/src/main/java/uca/github/org/services/RoleManagementService.java
+++ b/src/main/java/uca/github/org/services/RoleManagementService.java
@@ -14,5 +14,7 @@ public interface RoleManagementService {
 
     User assignRole(Long userId, Long roleId);
 
+    User assignRoles(Long userId, Set<Long> roleIds);
+
     Role updatePermissions(Long roleId, Set<Permission> permissions);
 }

--- a/src/main/java/uca/github/org/services/RoleManagementServiceImpl.java
+++ b/src/main/java/uca/github/org/services/RoleManagementServiceImpl.java
@@ -13,6 +13,7 @@ import uca.github.org.repositories.UserRepository;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -34,14 +35,24 @@ public class RoleManagementServiceImpl implements RoleManagementService {
     @Override
     @Transactional
     public User assignRole(Long userId, Long roleId) {
+        return assignRoles(userId, Set.of(roleId));
+    }
+
+    @Override
+    @Transactional
+    public User assignRoles(Long userId, Set<Long> roleIds) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("Utilisateur introuvable."));
-        Role role = roleRepository.findById(roleId)
-                .orElseThrow(() -> new EntityNotFoundException("Role introuvable."));
+        Set<Long> requestedRoleIds = roleIds == null ? Set.of() : roleIds;
+        List<Role> roles = roleRepository.findAllById(requestedRoleIds);
 
-        user.setRole(toLegacyRole(role));
+        if (roles.size() != requestedRoleIds.size()) {
+            throw new EntityNotFoundException("Un ou plusieurs roles sont introuvables.");
+        }
+
+        user.setRole(resolvePrimaryRole(roles));
         user.getAssignedRoles().clear();
-        user.getAssignedRoles().add(role);
+        user.getAssignedRoles().addAll(roles);
 
         return userRepository.save(user);
     }
@@ -56,11 +67,23 @@ public class RoleManagementServiceImpl implements RoleManagementService {
         return roleRepository.save(role);
     }
 
-    private User.Role toLegacyRole(Role role) {
-        try {
-            return User.Role.valueOf(role.getName());
-        } catch (IllegalArgumentException ex) {
+    private User.Role resolvePrimaryRole(List<Role> roles) {
+        Set<String> roleNames = roles.stream()
+                .map(Role::getName)
+                .collect(Collectors.toSet());
+
+        if (roleNames.contains(User.Role.ADMIN.name())) {
+            return User.Role.ADMIN;
+        }
+        if (roleNames.contains(User.Role.POSTER.name())) {
+            return User.Role.POSTER;
+        }
+        if (roleNames.contains(User.Role.USER.name())) {
             return User.Role.USER;
         }
+        if (roleNames.contains(User.Role.VISITOR.name())) {
+            return User.Role.VISITOR;
+        }
+        return User.Role.USER;
     }
 }

--- a/src/main/resources/templates/pages/admin/roles.html
+++ b/src/main/resources/templates/pages/admin/roles.html
@@ -95,6 +95,7 @@
           <th>Utilisateur</th>
           <th>Email</th>
           <th>Role principal</th>
+          <th>Roles assignes</th>
           <th class="text-end">Modifier</th>
         </tr>
         </thead>
@@ -106,17 +107,24 @@
           <td class="text-muted" th:text="${managedUser.email}">email@example.com</td>
           <td><span class="badge text-bg-secondary" th:text="${managedUser.role}">USER</span></td>
           <td>
-            <form th:action="@{/roles/users/assign}" method="post" class="d-flex justify-content-end gap-2">
+            <span class="badge text-bg-light me-1"
+                  th:each="assignedRole : ${managedUser.assignedRoles}"
+                  th:text="${assignedRole.label}">Role</span>
+          </td>
+          <td>
+            <form th:action="@{/roles/users/assign-many}" method="post" class="d-flex flex-column flex-xl-row justify-content-end gap-2">
               <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
               <input type="hidden" name="userId" th:value="${managedUser.id}">
-              <select class="form-select form-select-sm w-auto" name="roleId" aria-label="Role">
-                <option th:each="role : ${roles}"
-                        th:value="${role.id}"
-                        th:selected="${managedUser.role != null && managedUser.role.name() == role.name}"
-                        th:text="${role.label}">
-                  Role
-                </option>
-              </select>
+              <div class="d-flex flex-wrap justify-content-end gap-2">
+                <label class="form-check form-check-inline m-0" th:each="role : ${roles}">
+                  <input class="form-check-input"
+                         type="checkbox"
+                         name="roleIds"
+                         th:value="${role.id}"
+                         th:checked="${managedUser.assignedRoles.![id].contains(role.id)}">
+                  <span class="form-check-label small" th:text="${role.label}">Role</span>
+                </label>
+              </div>
               <button type="submit" class="btn btn-primary btn-sm">
                 <i class="bi bi-person-gear me-1"></i> Appliquer
               </button>

--- a/src/main/resources/templates/pages/admin/roles.html
+++ b/src/main/resources/templates/pages/admin/roles.html
@@ -69,7 +69,7 @@
                        name="permissions"
                        th:value="${permission}"
                        th:checked="${role.permissions.contains(permission)}">
-                <span class="form-check-label small" th:text="${permission}">PERMISSION</span>
+                <span class="form-check-label small" th:text="${permission.label}" th:title="${permission.description}">Permission</span>
               </label>
             </div>
             <button type="submit" class="btn btn-outline-primary btn-sm w-100">
@@ -121,7 +121,7 @@
                          type="checkbox"
                          name="roleIds"
                          th:value="${role.id}"
-                         th:checked="${managedUser.assignedRoles.![id].contains(role.id)}">
+                         th:checked="${managedUser.hasAssignedRole(role.id)}">
                   <span class="form-check-label small" th:text="${role.label}">Role</span>
                 </label>
               </div>

--- a/src/main/resources/templates/pages/admin/roles.html
+++ b/src/main/resources/templates/pages/admin/roles.html
@@ -30,10 +30,14 @@
 <main class="container-xl py-5">
   <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-end gap-3 mb-4">
     <div>
-      <h1 class="h2 fw-bold mb-2">Roles et controles d'acces</h1>
-      <p class="text-secondary mb-0">Gerez les permissions et l'affectation des roles aux utilisateurs.</p>
+      <h1 class="h2 fw-bold mb-2">Administration des roles</h1>
+      <p class="text-secondary mb-0">Pilotez les permissions et les acces des administrateurs, recruteurs et candidats.</p>
     </div>
-    <span class="badge text-bg-primary align-self-start align-self-lg-auto" th:text="${#lists.size(users)} + ' utilisateurs'">0 utilisateurs</span>
+    <div class="d-flex flex-wrap gap-2 align-self-start align-self-lg-auto">
+      <span class="badge text-bg-primary" th:text="${#lists.size(users)} + ' utilisateurs'">0 utilisateurs</span>
+      <span class="badge text-bg-secondary" th:text="${#lists.size(roles)} + ' roles'">0 roles</span>
+      <span class="badge text-bg-light" th:text="${#lists.size(permissions)} + ' permissions'">0 permissions</span>
+    </div>
   </div>
 
   <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}"></div>
@@ -50,11 +54,15 @@
             </div>
             <span class="badge text-bg-light" th:text="${role.name}">ADMIN</span>
           </div>
+          <div class="d-flex align-items-center gap-2 text-muted small mb-3">
+            <i class="bi bi-key"></i>
+            <span th:text="${role.permissions.size()} + ' permissions actives'">0 permissions actives</span>
+          </div>
 
           <form th:action="@{/roles/permissions}" method="post">
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
             <input type="hidden" name="roleId" th:value="${role.id}">
-            <div class="d-grid gap-2 mb-3">
+            <div class="row row-cols-1 g-2 mb-3">
               <label class="form-check" th:each="permission : ${permissions}">
                 <input class="form-check-input"
                        type="checkbox"
@@ -74,8 +82,11 @@
   </section>
 
   <section class="card">
-    <div class="card-header bg-white border-0 p-4">
-      <h2 class="h5 fw-bold mb-0">Affectation des roles</h2>
+    <div class="card-header bg-white border-0 p-4 d-flex flex-column flex-md-row justify-content-between gap-2">
+      <div>
+        <h2 class="h5 fw-bold mb-1">Affectation des roles</h2>
+        <p class="text-muted small mb-0">Vue rapide des acces par utilisateur.</p>
+      </div>
     </div>
     <div class="table-responsive">
       <table class="table align-middle mb-0">
@@ -83,7 +94,7 @@
         <tr>
           <th>Utilisateur</th>
           <th>Email</th>
-          <th>Role actuel</th>
+          <th>Role principal</th>
           <th class="text-end">Modifier</th>
         </tr>
         </thead>

--- a/src/test/java/uca/github/org/AccessControlServiceTest.java
+++ b/src/test/java/uca/github/org/AccessControlServiceTest.java
@@ -46,4 +46,22 @@ class AccessControlServiceTest {
 
         assertThat(accessControlService.canManageOwnOffers(user)).isFalse();
     }
+
+    @Test
+    void canAssignRoles_ShouldAllowManagedPermission() {
+        User user = User.builder()
+                .role(User.Role.USER)
+                .assignedRoles(new LinkedHashSet<>(Set.of(Role.builder()
+                        .name("PEOPLE_MANAGER")
+                        .permissions(new LinkedHashSet<>(Set.of(Permission.ASSIGN_ROLES)))
+                        .build())))
+                .build();
+
+        assertThat(accessControlService.canAssignRoles(user)).isTrue();
+    }
+
+    @Test
+    void canManageRoles_ShouldRejectNullUser() {
+        assertThat(accessControlService.canManageRoles(null)).isFalse();
+    }
 }

--- a/src/test/java/uca/github/org/AuthServiceTest.java
+++ b/src/test/java/uca/github/org/AuthServiceTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import uca.github.org.models.User;
@@ -34,7 +33,6 @@ import java.util.Optional;
  * 
  * @version 1.0
  */
-@SpringBootTest
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 

--- a/src/test/java/uca/github/org/HomepageDisplayTest.java
+++ b/src/test/java/uca/github/org/HomepageDisplayTest.java
@@ -7,17 +7,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -89,7 +88,7 @@ class HomepageDisplayTest {
                 .andExpect(content().string(containsString("Insight Lab")));
     }
 
-    @SpringBootConfiguration
+    @Configuration(proxyBeanMethods = false)
     @EnableAutoConfiguration
     @Import({ HomeController.class, InternConnectSecurityConfiguration.class })
     static class HomepageTestApplication {

--- a/src/test/java/uca/github/org/RoleManagementServiceTest.java
+++ b/src/test/java/uca/github/org/RoleManagementServiceTest.java
@@ -48,13 +48,40 @@ class RoleManagementServiceTest {
                 .build();
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(roleRepository.findById(2L)).thenReturn(Optional.of(posterRole));
+        when(roleRepository.findAllById(Set.of(2L))).thenReturn(java.util.List.of(posterRole));
         when(userRepository.save(user)).thenReturn(user);
 
         User result = roleManagementService.assignRole(1L, 2L);
 
         assertThat(result.getRole()).isEqualTo(User.Role.POSTER);
         assertThat(result.getAssignedRoles()).containsExactly(posterRole);
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void assignRoles_ShouldKeepHighestLegacyRoleAsPrimary() {
+        User user = User.builder()
+                .id(1L)
+                .role(User.Role.USER)
+                .build();
+        Role userRole = Role.builder()
+                .id(2L)
+                .name("USER")
+                .build();
+        Role adminRole = Role.builder()
+                .id(3L)
+                .name("ADMIN")
+                .build();
+        Set<Long> roleIds = Set.of(2L, 3L);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(roleRepository.findAllById(roleIds)).thenReturn(java.util.List.of(userRole, adminRole));
+        when(userRepository.save(user)).thenReturn(user);
+
+        User result = roleManagementService.assignRoles(1L, roleIds);
+
+        assertThat(result.getRole()).isEqualTo(User.Role.ADMIN);
+        assertThat(result.getAssignedRoles()).containsExactlyInAnyOrder(userRole, adminRole);
         verify(userRepository).save(user);
     }
 


### PR DESCRIPTION
# UCA-61 Manage admin, poster, and candidate roles

**Description:**

This PR implements role management for admin, poster, and candidate users.

### Changes

* Added role-based access checks.
* Created the `/roles` backend endpoint.
* Designed the role management UI.
* Added user role assignment management.
* Updated the data model for roles and permissions.
* Added tests for role and access management.

### Commits

```text
c349b90 UCA-170 Implement role-based access checks
1032775 UCA-171 Create the backend /roles endpoint for role management
eff34a95 UCA-172 Design the role management interface
da13427 UCA-173 Manage role assignment to users
cdfc430 UCA-174 Update the data model for roles and permissions
6e73a64 UCA-175 Write tests for role and access management
```

### Branch

```bash
feature/UCA-61-manage-admin-poster-candidate-roles
```