### PR TITLE
Feature/uca-187-calculate-candidate-offer-match-score

### DIFF
--- a/src/main/java/uca/github/org/controllers/InternshipController.java
+++ b/src/main/java/uca/github/org/controllers/InternshipController.java
@@ -5,7 +5,10 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import uca.github.org.matching.CandidateMatchingService;
 import uca.github.org.models.User;
 import uca.github.org.repositories.InternshipRepository;
 
@@ -14,6 +17,7 @@ import uca.github.org.repositories.InternshipRepository;
 public class InternshipController {
 
     private final InternshipRepository internshipRepository;
+    private final CandidateMatchingService candidateMatchingService;
 
     @GetMapping("/internships")
     public String internships(
@@ -29,5 +33,32 @@ public class InternshipController {
         model.addAttribute("user", currentUser);
 
         return "internships";
+    }
+
+    @GetMapping("/internships/{id}")
+    public String internshipDetails(
+            @PathVariable Long id,
+            Model model,
+            @AuthenticationPrincipal User currentUser,
+            RedirectAttributes redirectAttributes) {
+
+        var offer = internshipRepository.findById(id);
+        if (offer.isEmpty()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Offre introuvable.");
+            return "redirect:/internships";
+        }
+
+        model.addAttribute("offer", offer.get());
+        model.addAttribute("user", currentUser);
+
+        if (canViewCandidateMatches(currentUser)) {
+            model.addAttribute("candidateMatches", candidateMatchingService.findMatchesForOffer(id));
+        }
+
+        return "pages/offers/details";
+    }
+
+    private boolean canViewCandidateMatches(User user) {
+        return user != null && (user.getRole() == User.Role.POSTER || user.getRole() == User.Role.ADMIN);
     }
 }

--- a/src/main/java/uca/github/org/matching/CandidateMatchingController.java
+++ b/src/main/java/uca/github/org/matching/CandidateMatchingController.java
@@ -1,0 +1,26 @@
+package uca.github.org.matching;
+
+import java.util.List;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import uca.github.org.matching.dto.CandidateMatchDTO;
+
+@RestController
+@RequestMapping("/api/offers")
+@RequiredArgsConstructor
+public class CandidateMatchingController {
+
+    private final CandidateMatchingService candidateMatchingService;
+
+    @GetMapping("/{offerId}/matches")
+    @PreAuthorize("hasAnyRole('POSTER', 'RECRUITER', 'ADMIN')")
+    public List<CandidateMatchDTO> findMatchesForOffer(@PathVariable Long offerId) {
+        return candidateMatchingService.findMatchesForOffer(offerId);
+    }
+}

--- a/src/main/java/uca/github/org/matching/CandidateMatchingService.java
+++ b/src/main/java/uca/github/org/matching/CandidateMatchingService.java
@@ -1,0 +1,10 @@
+package uca.github.org.matching;
+
+import java.util.List;
+
+import uca.github.org.matching.dto.CandidateMatchDTO;
+
+public interface CandidateMatchingService {
+
+    List<CandidateMatchDTO> findMatchesForOffer(Long offerId);
+}

--- a/src/main/java/uca/github/org/matching/CandidateMatchingServiceImpl.java
+++ b/src/main/java/uca/github/org/matching/CandidateMatchingServiceImpl.java
@@ -1,0 +1,185 @@
+package uca.github.org.matching;
+
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import uca.github.org.matching.dto.CandidateMatchDTO;
+import uca.github.org.models.Internship;
+import uca.github.org.models.Profile;
+import uca.github.org.models.User;
+import uca.github.org.repositories.InternshipRepository;
+import uca.github.org.repositories.ProfileRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CandidateMatchingServiceImpl implements CandidateMatchingService {
+
+    private static final Pattern SPLIT_PATTERN = Pattern.compile("[,;|/\\n\\r\\t]+");
+
+    private final InternshipRepository internshipRepository;
+    private final ProfileRepository profileRepository;
+
+    @Override
+    public List<CandidateMatchDTO> findMatchesForOffer(Long offerId) {
+        Internship offer = internshipRepository.findById(offerId)
+                .orElseThrow(() -> new IllegalArgumentException("Offer not found."));
+
+        return profileRepository.findAll().stream()
+                .filter(profile -> isCandidate(profile.getUser()))
+                .map(profile -> scoreCandidate(offer, profile))
+                .filter(result -> result.getScore() >= MatchingWeights.MIN_RELEVANT_SCORE)
+                .sorted(Comparator.comparingInt(CandidateMatchDTO::getScore).reversed()
+                        .thenComparing(CandidateMatchDTO::getFullName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
+                .toList();
+    }
+
+    CandidateMatchDTO scoreCandidate(Internship offer, Profile profile) {
+        User candidate = profile.getUser();
+        int score = 0;
+        List<String> matchedCriteria = new ArrayList<>();
+
+        if (hasSkillsMatch(offer, profile)) {
+            score += MatchingWeights.SKILLS;
+            matchedCriteria.add("Skills");
+        }
+
+        if (containsAny(profile.getPreferredSector(), offer.getSector())
+                || containsAny(profile.getPreferences(), offer.getSector())
+                || containsAny(profile.getDescription(), offer.getSector())) {
+            score += MatchingWeights.FIELD;
+            matchedCriteria.add("Field");
+        }
+
+        if (containsAny(profile.getEducation(), offer.getEducationLevel())) {
+            score += MatchingWeights.LEVEL;
+            matchedCriteria.add("Education Level");
+        }
+
+        if (locationCompatible(offer, profile)) {
+            score += MatchingWeights.LOCATION;
+            matchedCriteria.add("Location");
+        }
+
+        if (availabilityCompatible(offer, profile)) {
+            score += MatchingWeights.AVAILABILITY;
+            matchedCriteria.add("Availability");
+        }
+
+        return CandidateMatchDTO.builder()
+                .candidateId(candidate.getId())
+                .fullName(fullName(candidate))
+                .email(candidate.getEmail())
+                .score(score)
+                .matchedCriteria(matchedCriteria)
+                .aiExplanation(null)
+                .build();
+    }
+
+    private boolean isCandidate(User user) {
+        return user != null && user.getRole() == User.Role.USER;
+    }
+
+    private boolean hasSkillsMatch(Internship offer, Profile profile) {
+        Set<String> offerSkills = tokens(offer.getRequiredSkills());
+        if (offerSkills.isEmpty()) {
+            return false;
+        }
+
+        Set<String> candidateTerms = tokens(String.join(" ",
+                clean(profile.getSkills()),
+                clean(profile.getExperience()),
+                clean(profile.getDescription()),
+                clean(profile.getPreferredKeywords())));
+
+        return offerSkills.stream().anyMatch(candidateTerms::contains);
+    }
+
+    private boolean locationCompatible(Internship offer, Profile profile) {
+        String offerLocation = clean(offer.getLocation());
+        String preferredLocation = clean(profile.getPreferredLocation());
+        String preferences = clean(profile.getPreferences());
+
+        if (isRemote(offerLocation) || isRemote(preferredLocation) || isRemote(preferences)) {
+            return true;
+        }
+
+        return containsAny(preferredLocation, offerLocation) || containsAny(preferences, offerLocation);
+    }
+
+    private boolean availabilityCompatible(Internship offer, Profile profile) {
+        String duration = clean(offer.getDuration());
+        if (duration.isBlank()) {
+            return false;
+        }
+
+        return containsAny(profile.getPreferences(), duration)
+                || containsAny(profile.getDescription(), duration)
+                || containsAny(profile.getCoverLetter(), duration);
+    }
+
+    private boolean containsAny(String text, String expected) {
+        Set<String> expectedTokens = tokens(expected);
+        if (expectedTokens.isEmpty()) {
+            return false;
+        }
+
+        Set<String> actualTokens = tokens(text);
+        return expectedTokens.stream().anyMatch(actualTokens::contains);
+    }
+
+    private Set<String> tokens(String value) {
+        Set<String> tokens = new LinkedHashSet<>();
+        String normalized = normalize(value);
+        if (normalized.isBlank()) {
+            return tokens;
+        }
+
+        for (String part : SPLIT_PATTERN.split(normalized)) {
+            String token = part.trim();
+            if (!token.isBlank()) {
+                tokens.add(token);
+            }
+        }
+
+        for (String token : normalized.split("\\s+")) {
+            if (!token.isBlank()) {
+                tokens.add(token);
+            }
+        }
+
+        return tokens;
+    }
+
+    private boolean isRemote(String value) {
+        String normalized = normalize(value);
+        return normalized.contains("remote")
+                || normalized.contains("hybrid")
+                || normalized.contains("hybride")
+                || normalized.contains("distance");
+    }
+
+    private String normalize(String value) {
+        String cleaned = clean(value).toLowerCase(Locale.ROOT);
+        String withoutAccents = Normalizer.normalize(cleaned, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "");
+        return withoutAccents.replaceAll("[^a-z0-9+#.]+", " ").trim();
+    }
+
+    private String clean(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private String fullName(User user) {
+        String fullName = (clean(user.getFirstName()) + " " + clean(user.getLastName())).trim();
+        return fullName.isBlank() ? user.getEmail() : fullName;
+    }
+}

--- a/src/main/java/uca/github/org/matching/MatchingWeights.java
+++ b/src/main/java/uca/github/org/matching/MatchingWeights.java
@@ -1,0 +1,14 @@
+package uca.github.org.matching;
+
+public final class MatchingWeights {
+
+    public static final int SKILLS = 50;
+    public static final int FIELD = 20;
+    public static final int LEVEL = 15;
+    public static final int LOCATION = 10;
+    public static final int AVAILABILITY = 5;
+    public static final int MIN_RELEVANT_SCORE = 50;
+
+    private MatchingWeights() {
+    }
+}

--- a/src/main/java/uca/github/org/matching/dto/CandidateMatchDTO.java
+++ b/src/main/java/uca/github/org/matching/dto/CandidateMatchDTO.java
@@ -1,0 +1,24 @@
+package uca.github.org.matching.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CandidateMatchDTO {
+
+    private Long candidateId;
+    private String fullName;
+    private String email;
+    private int score;
+    private List<String> matchedCriteria;
+    private String aiExplanation;
+}

--- a/src/main/resources/templates/pages/offers/details.html
+++ b/src/main/resources/templates/pages/offers/details.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="fr"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>InternConnect - Offre</title>
+  <link rel="stylesheet" th:href="@{/assets/css/main.css}">
+  <script th:src="@{/assets/js/main.js}" defer></script>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+
+<div th:replace="~{fragments/navbar :: main('internships')}"></div>
+
+<main class="container-xl py-5">
+  <section class="card card-soft mb-4">
+    <div class="card-body p-4">
+      <div class="d-flex flex-column flex-lg-row justify-content-between gap-3">
+        <div>
+          <span class="badge text-bg-primary mb-3" th:text="${offer.sector != null ? offer.sector : 'Stage'}">Stage</span>
+          <h1 class="display-6 fw-bold mb-2" th:text="${offer.title}">Titre de l'offre</h1>
+          <p class="text-muted mb-0">
+            <span th:text="${offer.company != null ? offer.company : 'Entreprise'}">Entreprise</span>
+            <span th:if="${offer.location != null}"> · <span th:text="${offer.location}">Ville</span></span>
+          </p>
+        </div>
+        <div class="text-lg-end">
+          <span class="badge text-bg-success" th:text="${offer.status}">ACTIVE</span>
+          <p class="small text-muted mt-2 mb-0" th:if="${offer.duration != null}" th:text="${offer.duration}">3 mois</p>
+        </div>
+      </div>
+
+      <hr class="my-4">
+
+      <div class="row g-4">
+        <div class="col-lg-8">
+          <h2 class="h5 fw-bold">Description</h2>
+          <p class="text-muted" th:text="${offer.description != null ? offer.description : 'Description non disponible.'}">
+            Description de l'offre.
+          </p>
+        </div>
+        <div class="col-lg-4">
+          <div class="card bg-light border-0">
+            <div class="card-body">
+              <h2 class="h6 fw-bold">Profil recherche</h2>
+              <dl class="small mb-0">
+                <dt>Competences</dt>
+                <dd th:text="${offer.requiredSkills != null ? offer.requiredSkills : 'Non precise'}">Java</dd>
+                <dt>Niveau</dt>
+                <dd th:text="${offer.educationLevel != null ? offer.educationLevel : 'Non precise'}">Master</dd>
+                <dt>Contact</dt>
+                <dd th:text="${offer.contactEmail != null ? offer.contactEmail : 'Non precise'}">contact@example.com</dd>
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="card card-soft" sec:authorize="hasAnyRole('POSTER','ADMIN')">
+    <div class="card-body p-4">
+      <div class="d-flex align-items-center justify-content-between gap-3 mb-3">
+        <div>
+          <h2 class="h4 fw-bold mb-1">Recommended Candidates</h2>
+          <p class="text-muted mb-0">Candidates with a score of 50 or higher for this offer.</p>
+        </div>
+        <span class="badge text-bg-primary rounded-pill"
+              th:text="${candidateMatches != null ? #lists.size(candidateMatches) : 0}">0</span>
+      </div>
+
+      <div th:if="${candidateMatches == null || #lists.isEmpty(candidateMatches)}"
+           class="alert alert-secondary mb-0">
+        No relevant candidates found for this offer.
+      </div>
+
+      <div th:if="${candidateMatches != null && !#lists.isEmpty(candidateMatches)}"
+           class="table-responsive">
+        <table class="table align-middle mb-0">
+          <thead>
+          <tr>
+            <th>Candidate</th>
+            <th>Email</th>
+            <th>Score</th>
+            <th>Matched Criteria</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr th:each="match : ${candidateMatches}">
+            <td class="fw-semibold" th:text="${match.fullName}">Candidate Name</td>
+            <td th:text="${match.email}">candidate@example.com</td>
+            <td>
+              <span class="badge text-bg-success" th:text="${match.score + '/100'}">85/100</span>
+            </td>
+            <td>
+              <span th:each="criterion : ${match.matchedCriteria}"
+                    class="badge text-bg-light border me-1 mb-1"
+                    th:text="${criterion}">Skills</span>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+</main>
+
+</body>
+</html>

--- a/src/test/java/uca/github/org/matching/CandidateMatchingControllerTest.java
+++ b/src/test/java/uca/github/org/matching/CandidateMatchingControllerTest.java
@@ -1,0 +1,42 @@
+package uca.github.org.matching;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import uca.github.org.matching.dto.CandidateMatchDTO;
+
+class CandidateMatchingControllerTest {
+
+    @Test
+    void findMatchesForOffer_ShouldReturnJsonResponse() throws Exception {
+        CandidateMatchingService service = org.mockito.Mockito.mock(CandidateMatchingService.class);
+        CandidateMatchingController controller = new CandidateMatchingController(service);
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+        when(service.findMatchesForOffer(10L)).thenReturn(List.of(CandidateMatchDTO.builder()
+                .candidateId(1L)
+                .fullName("Mohamed Lafrouh")
+                .email("mohamed@example.com")
+                .score(85)
+                .matchedCriteria(List.of("Skills", "Field", "Location"))
+                .aiExplanation(null)
+                .build()));
+
+        mockMvc.perform(get("/api/offers/10/matches"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Mohamed Lafrouh")))
+                .andExpect(jsonPath("$[0].candidateId").value(1))
+                .andExpect(jsonPath("$[0].score").value(85))
+                .andExpect(jsonPath("$[0].matchedCriteria[0]").value("Skills"));
+    }
+}

--- a/src/test/java/uca/github/org/matching/CandidateMatchingServiceTest.java
+++ b/src/test/java/uca/github/org/matching/CandidateMatchingServiceTest.java
@@ -1,0 +1,115 @@
+package uca.github.org.matching;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uca.github.org.matching.dto.CandidateMatchDTO;
+import uca.github.org.models.Internship;
+import uca.github.org.models.Profile;
+import uca.github.org.models.User;
+import uca.github.org.repositories.InternshipRepository;
+import uca.github.org.repositories.ProfileRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CandidateMatchingServiceTest {
+
+    @Mock
+    private InternshipRepository internshipRepository;
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @InjectMocks
+    private CandidateMatchingServiceImpl candidateMatchingService;
+
+    @Test
+    void findMatchesForOffer_ShouldGiveHighScore_WhenSkillsMatch() {
+        Internship offer = offer();
+        Profile candidate = profile(1L, "Mohamed", "Lafrouh", "Java, Spring Boot, MySQL",
+                "Software Development", "Master", "Casablanca", "Available for 6 months");
+
+        when(internshipRepository.findById(10L)).thenReturn(Optional.of(offer));
+        when(profileRepository.findAll()).thenReturn(List.of(candidate));
+
+        List<CandidateMatchDTO> matches = candidateMatchingService.findMatchesForOffer(10L);
+
+        assertEquals(1, matches.size());
+        assertTrue(matches.get(0).getScore() >= 50);
+        assertTrue(matches.get(0).getMatchedCriteria().contains("Skills"));
+    }
+
+    @Test
+    void findMatchesForOffer_ShouldFilterCandidate_WhenNoCriteriaMatch() {
+        Internship offer = offer();
+        Profile candidate = profile(2L, "Noor", "Amrani", "Design, Figma",
+                "Graphic Design", "Bachelor", "Tangier", "Part-time only");
+
+        when(internshipRepository.findById(10L)).thenReturn(Optional.of(offer));
+        when(profileRepository.findAll()).thenReturn(List.of(candidate));
+
+        List<CandidateMatchDTO> matches = candidateMatchingService.findMatchesForOffer(10L);
+
+        assertTrue(matches.isEmpty());
+    }
+
+    @Test
+    void findMatchesForOffer_ShouldSortResultsByScoreDescending() {
+        Internship offer = offer();
+        Profile strongCandidate = profile(1L, "Amina", "Safi", "Java, Spring Boot, MySQL",
+                "Software Development", "Master", "Casablanca", "Available for 6 months");
+        Profile skillsOnlyCandidate = profile(2L, "Yassine", "Berrada", "Java",
+                "Marketing", "Bachelor", "Rabat", "Available now");
+
+        when(internshipRepository.findById(10L)).thenReturn(Optional.of(offer));
+        when(profileRepository.findAll()).thenReturn(List.of(skillsOnlyCandidate, strongCandidate));
+
+        List<CandidateMatchDTO> matches = candidateMatchingService.findMatchesForOffer(10L);
+
+        assertFalse(matches.isEmpty());
+        assertEquals(1L, matches.get(0).getCandidateId());
+        assertTrue(matches.get(0).getScore() > matches.get(1).getScore());
+    }
+
+    private Internship offer() {
+        return Internship.builder()
+                .id(10L)
+                .title("Backend Developer Intern")
+                .requiredSkills("Java, Spring Boot, MySQL")
+                .sector("Software Development")
+                .educationLevel("Master")
+                .location("Casablanca")
+                .duration("6 months")
+                .build();
+    }
+
+    private Profile profile(Long id, String firstName, String lastName, String skills, String sector,
+                            String education, String location, String preferences) {
+        User user = User.builder()
+                .id(id)
+                .firstName(firstName)
+                .lastName(lastName)
+                .email(firstName.toLowerCase() + "@example.com")
+                .role(User.Role.USER)
+                .build();
+
+        return Profile.builder()
+                .user(user)
+                .skills(skills)
+                .preferredSector(sector)
+                .education(education)
+                .preferredLocation(location)
+                .preferences(preferences)
+                .build();
+    }
+}

--- a/src/test/java/uca/github/org/matching/OfferDetailsTemplateTest.java
+++ b/src/test/java/uca/github/org/matching/OfferDetailsTemplateTest.java
@@ -1,0 +1,20 @@
+package uca.github.org.matching;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class OfferDetailsTemplateTest {
+
+    @Test
+    void offerDetailsTemplate_ShouldDisplayCandidateMatchingSection() throws Exception {
+        String template = Files.readString(Path.of("src/main/resources/templates/pages/offers/details.html"));
+
+        assertTrue(template.contains("Recommended Candidates"));
+        assertTrue(template.contains("No relevant candidates found for this offer."));
+        assertTrue(template.contains("Matched Criteria"));
+    }
+}


### PR DESCRIPTION
## Summary

This pull request implements a lightweight candidate-offer matching feature for the monolithic Spring Boot application.

The system now calculates a rule-based matching score between internship offers and candidate profiles, allowing recruiters to quickly identify the most relevant candidates for an offer.

## User Story

**UCA-187 — Calculate candidate-offer match score**

As a system, I want to calculate a matching score between an internship offer and candidate profiles so that recruiters can quickly identify the most relevant candidates.

## Implemented Subtasks

- **UCA-188** Define offer-candidate matching criteria
- **UCA-189** Create matching result DTOs
- **UCA-190** Implement scoring service and matching endpoint
- **UCA-191** Display and test matching results

## Changes Made

### Matching Criteria

A lightweight rule-based scoring system was added using the following criteria:

| Criterion | Points |
|---|---:|
| Skills match | 50 |
| Field / specialty match | 20 |
| Education level match | 15 |
| Location or remote compatibility | 10 |
| Availability compatibility | 5 |

Only candidates with a score greater than or equal to 50 are considered relevant.

### Backend

Added the matching module with:

- Matching weights configuration
- Candidate matching DTO
- Candidate matching service
- Candidate matching service implementation
- Matching REST endpoint

New endpoint:

```http
GET /api/offers/{offerId}/matches